### PR TITLE
Fix URL path joining to handle empty relative paths

### DIFF
--- a/pkg/client/api_client.go
+++ b/pkg/client/api_client.go
@@ -101,7 +101,13 @@ func (cl *APIClient) get(ctx context.Context, path string) ([]byte, error) {
 	cl.sem.Acquire(context.Background(), 1)
 	defer cl.sem.Release(1)
 
-	uri := strings.Trim(cl.url, "/") + "/" + strings.Trim(path, "/")
+	baseURL := strings.TrimSuffix(cl.url, "/")
+	relativePath := strings.TrimPrefix(path, "/")
+
+	uri := baseURL
+	if relativePath != "" {
+		uri += "/" + relativePath
+	}
 
 	_, span := cl.tracer.Start(ctx, "Client.Get", trace.WithAttributes(
 		attribute.String("URI", uri),


### PR DESCRIPTION
Thanks for maintaining this exporter—it’s been very helpful for our monitoring setup.
 
- Problem: Redfish requests such as /redfish/v1/Systems/1/SmartStorage/ArrayControllers/0/DiskDrives/ were normalized to a URL without the trailing slash, causing iLO to return 404 and logging could not get drives for controller /redfish/v1/Systems/1/SmartStorage/ArrayControllers/0.

- Fix: adjust URL assembly in pkg/client/api_client.go:104 so relative paths are appended to the base https://…/redfish/v1/ without trimming the trailing slash. Requests now return 200 and SmartStorage disk metrics (e.g. ilo_storage_disk_capacity_byte) are populated again. Verification: run the exporter and curl http://localhost:9545/metrics?host=<ip>.
