### PR TITLE
Added reading OS variabled API_USERNAME and API_PASSWORD

### DIFF
--- a/main.go
+++ b/main.go
@@ -53,6 +53,12 @@ func init() {
 func main() {
 	flag.Parse()
 
+	// Read API_USERNAME and API_PASSWORD from environment variablegit@github.com:bbruun/ilo_exporter.gits
+	if *username == "" || *password == "" {
+		*username = os.Getenv("API_USERNAME")
+		*password = os.Getenv("API_PASSWORD")
+	}
+
 	if *showVersion {
 		printVersion()
 		os.Exit(0)


### PR DESCRIPTION
This was added to run ilo_exporter without showing credentials via "ps xa" by any user on a system running it as if it is started with `-api.username=user -api.password=pass` then `ps xa |grep ilo_exporter` will show credentials in cleartext so I added the few lines to enable running it as a systemd service or via a container without using the two parameters that divulge credentials.

Example:
In terminal 1:
```
$ ./ilo_exporter -api.username=ilo-exporter -api.password=password
```
In terminal 2:
``` 
$ ps xa |grep ilo
 416221 ?        Ssl    0:39 ./ilo_exporter -api.username=ilo-exporter -api.password=password
``` 

The systemd service file: `/etc/systemd/system/ilo_exporter.service`
(with a copy of ilo_exporter in /usr/local/bin/ with chown nobody:nobody and chmod +x)

```
[Service]
[Unit]
Description=HP iLO Prometheus exporter
Documentation=https://github.com/MauveSoftware/ilo_exporter Wants=network-online.target
After=network-online.target

[Install]
WantedBy=multi-user.target

[Service]
Type=simple
User=nobody
Group=nobody
ExecStart=/usr/local/bin/ilo_exporter -api.max-concurrent-requests=50 Restart=always
```

Systemd override conf file `/etc/systemd/system/ilo_exporter.service.d/override.conf` with chmod 600 and chown nobody:nobody
```
[Service]
Environment="API_USERNAME=ilo-exporter"
Environment="API_PASSWORD=password"
``` 
